### PR TITLE
Update sockjs-protocol-0.3.3.py

### DIFF
--- a/sockjs-protocol-0.3.3.py
+++ b/sockjs-protocol-0.3.3.py
@@ -567,10 +567,10 @@ class WebsocketHixie76(Test):
         ws2 = websocket.create_connection(ws_url, on_close=on_close)
         self.assertEqual(ws2.recv(), u'o')
 
-        ws1.send(u'"a"')
+        ws1.send(u'["a"]')
         self.assertEqual(ws1.recv(), u'a["a"]')
 
-        ws2.send(u'"b"')
+        ws2.send(u'["b"]')
         self.assertEqual(ws2.recv(), u'a["b"]')
 
         ws1.close()
@@ -580,7 +580,7 @@ class WebsocketHixie76(Test):
         # previous connection.
         ws1 = websocket.create_connection(ws_url)
         self.assertEqual(ws1.recv(), u'o')
-        ws1.send(u'"a"')
+        ws1.send(u'["a"]')
         self.assertEqual(ws1.recv(), u'a["a"]')
         ws1.close()
 


### PR DESCRIPTION
Are these messages just "string" values and not "array of string" on purpose? All other tests send arrays, not plain string values. And especially considering the name of this particular test "test_reuseSessionId". IMO the test should focus on session reuse, not the payload.
