### PR TITLE
Use 400 HTTP response instead of 500 for invalid requests

### DIFF
--- a/sockjs-protocol-dev.py
+++ b/sockjs-protocol-dev.py
@@ -1097,7 +1097,7 @@ class JsonPolling(Test):
 
     def test_no_callback(self):
         r = GET(base_url + '/a/a/jsonp')
-        self.assertEqual(r.status, 4500)
+        self.assertEqual(r.status, 400)
         self.assertTrue('"callback" parameter required' in r.body)
 
     # Supplying invalid characters to callback parameter is invalid


### PR DESCRIPTION
According to HTTP/1.1 the status code 500 means "Internal Server Error". It would make much more sense to use 400 instead, meaning "Bad Request" in case of invalid json, empty json or any other invalid request.
