### PR TITLE
Introduce 0.25 sec delay for concurrent poll requests

### DIFF
--- a/sockjs-protocol-0.3.3.py
+++ b/sockjs-protocol-0.3.3.py
@@ -453,6 +453,7 @@ class Protocol(Test):
         # on a single session. In such case the server must send a
         # close frame to the new connection.
         r1 = old_POST_async(trans_url + '/xhr', load=False)
+        time.sleep(0.25)
         r2 = POST(trans_url + '/xhr')
 
         self.assertEqual(r2.body, 'c[2010,"Another connection still open"]\n')
@@ -1389,6 +1390,7 @@ class HandlingClose(Test):
         self.assertEqual(r1.body, 'o\n')
 
         r1 = old_POST_async(url + '/xhr', load=False)
+        time.sleep(0.25)
 
         # Can't do second polling request now.
         r2 = POST(url + '/xhr')


### PR DESCRIPTION
On Java Servlet containers, requests are processed in concurrent threads
and it's not possible to guarantee the order of processing. This
change introduces a 0.25 sec delay between requests when testing
simultaneous polling requests to maximize the chance of the first
request to be processed first.
