### PR TITLE
Adding support for multiple single HTTP header entries.

### DIFF
--- a/utils_03.py
+++ b/utils_03.py
@@ -211,8 +211,10 @@ class RawHttpConnection(object):
             if header in ['\n', '\r\n']:
                 break
             k, _, v = header.partition(':')
-            resp.headers[k] = v.lstrip().rstrip('\r\n')
-
+            if k in resp.headers:
+                resp.headers[k] = resp.headers[k] + ', ' + v.lstrip().rstrip('\r\n')
+            else:
+                resp.headers[k] = v.lstrip().rstrip('\r\n')
         return resp
 
     def read(self, size=None):


### PR DESCRIPTION
When parsing a HTTP response that has multiple HTTP headers as single
entries, as opposed to a single header with a comma separated list of
values, only the last value was added to the dictionary of headers.

This addition checks if the header name has already been added to the
dictionary, and if so, appends the value to the already existing key's
value.