### PR TITLE
Support \n as new line delimiter for EventSource

### DIFF
--- a/sockjs-protocol-0.3.3.py
+++ b/sockjs-protocol-0.3.3.py
@@ -907,15 +907,15 @@ class EventSource(Test):
 
         # The transport must first send a new line prelude, due to a
         # bug in Opera.
-        self.assertEqual(r.read(), '\r\n')
+        self.assertRegexpMatches(r.read(), '(\r)?\n')
 
-        self.assertEqual(r.read(), 'data: o\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
 
         r1 = POST(url + '/xhr_send', body='["x"]')
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertEqual(r.read(), 'data: a["x"]\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r)?\n(\r)?\n')
 
         # This protocol doesn't allow binary data and we need to
         # specially treat leading space, new lines and things like
@@ -925,8 +925,8 @@ class EventSource(Test):
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertEqual(r.read(),
-                         'data: a["  \\u0000\\n\\r "]\r\n\r\n')
+        self.assertIn(r.read(),
+        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\n\r\n']])
 
         r.close()
 
@@ -942,14 +942,14 @@ class EventSource(Test):
         r = GET_async(url + '/eventsource')
         self.assertEqual(r.status, 200)
         self.assertTrue(r.read()) # prelude
-        self.assertEqual(r.read(), 'data: o\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
 
         # Test server should gc streaming session after 4096 bytes
         # were sent (including framing).
         msg = '"' + ('x' * 4096) + '"'
         r1 = POST(url + '/xhr_send', body='[' + msg + ']')
         self.assertEqual(r1.status, 204)
-        self.assertEqual(r.read(), 'data: a[' + msg + ']\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: a\[' + msg + '\](\r)?\n(\r)?\n')
 
         # The connection should be closed after enough data was
         # delivered.

--- a/sockjs-protocol-0.3.3.py
+++ b/sockjs-protocol-0.3.3.py
@@ -907,15 +907,15 @@ class EventSource(Test):
 
         # The transport must first send a new line prelude, due to a
         # bug in Opera.
-        self.assertRegexpMatches(r.read(), '(\r)?\n')
+        self.assertRegexpMatches(r.read(), '\r|\n')
 
-        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r|\n)(\r|\n)')
 
         r1 = POST(url + '/xhr_send', body='["x"]')
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r|\n)(\r|\n)')
 
         # This protocol doesn't allow binary data and we need to
         # specially treat leading space, new lines and things like
@@ -926,7 +926,7 @@ class EventSource(Test):
         self.assertEqual(r1.status, 204)
 
         self.assertIn(r.read(),
-        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\n\r\n']])
+        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\r', '\r\n\r\n']])
 
         r.close()
 
@@ -942,14 +942,14 @@ class EventSource(Test):
         r = GET_async(url + '/eventsource')
         self.assertEqual(r.status, 200)
         self.assertTrue(r.read()) # prelude
-        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r|\n)(\r|\n)')
 
         # Test server should gc streaming session after 4096 bytes
         # were sent (including framing).
         msg = '"' + ('x' * 4096) + '"'
         r1 = POST(url + '/xhr_send', body='[' + msg + ']')
         self.assertEqual(r1.status, 204)
-        self.assertRegexpMatches(r.read(), 'data: a\[' + msg + '\](\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: a\[' + msg + '\](\r|\n)(\r|\n)')
 
         # The connection should be closed after enough data was
         # delivered.

--- a/sockjs-protocol-dev.py
+++ b/sockjs-protocol-dev.py
@@ -933,15 +933,15 @@ class EventSource(Test):
 
         # The transport must first send a new line prelude, due to a
         # bug in Opera.
-        self.assertEqual(r.read(), '\r\n')
+        self.assertRegexpMatches(r.read(), '(\r)?\n')
 
-        self.assertEqual(r.read(), 'data: o\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
 
         r1 = POST(url + '/xhr_send', body='["x"]')
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertEqual(r.read(), 'data: a["x"]\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r)?\n(\r)?\n')
 
         # This protocol doesn't allow binary data and we need to
         # specially treat leading space, new lines and things like
@@ -951,8 +951,8 @@ class EventSource(Test):
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertEqual(r.read(),
-                         'data: a["  \\u0000\\n\\r "]\r\n\r\n')
+        self.assertIn(r.read(),
+        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\n\r\n']])
 
         r.close()
 

--- a/sockjs-protocol-dev.py
+++ b/sockjs-protocol-dev.py
@@ -952,7 +952,7 @@ class EventSource(Test):
         self.assertEqual(r1.status, 204)
 
         self.assertIn(r.read(),
-        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\n\r\n']])
+        	['data: a["  \\u0000\\n\\r "]' + nl for nl in ['\n\n', '\r\r', '\r\n\r\n']])
 
         r.close()
 

--- a/sockjs-protocol-dev.py
+++ b/sockjs-protocol-dev.py
@@ -933,15 +933,15 @@ class EventSource(Test):
 
         # The transport must first send a new line prelude, due to a
         # bug in Opera.
-        self.assertRegexpMatches(r.read(), '(\r)?\n')
+        self.assertRegexpMatches(r.read(), '\r|\n')
 
-        self.assertRegexpMatches(r.read(), 'data: o(\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r|\n)(\r|\n)')
 
         r1 = POST(url + '/xhr_send', body='["x"]')
         self.assertFalse(r1.body)
         self.assertEqual(r1.status, 204)
 
-        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r)?\n(\r)?\n')
+        self.assertRegexpMatches(r.read(), 'data: a\["x"\](\r|\n)(\r|\n)')
 
         # This protocol doesn't allow binary data and we need to
         # specially treat leading space, new lines and things like
@@ -968,14 +968,14 @@ class EventSource(Test):
         r = GET_async(url + '/eventsource')
         self.assertEqual(r.status, 200)
         self.assertTrue(r.read()) # prelude
-        self.assertEqual(r.read(), 'data: o\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: o(\r|\n)(\r|\n)')
 
         # Test server should gc streaming session after 4096 bytes
         # were sent (including framing).
         msg = '"' + ('x' * 4096) + '"'
         r1 = POST(url + '/xhr_send', body='[' + msg + ']')
         self.assertEqual(r1.status, 204)
-        self.assertEqual(r.read(), 'data: a[' + msg + ']\r\n\r\n')
+        self.assertRegexpMatches(r.read(), 'data: a\[' + msg + '\](\r|\n)(\r|\n)')
 
         # The connection should be closed after enough data was
         # delivered.


### PR DESCRIPTION
EventSource spec allows to use \n only as end of line delimiter (http://www.w3.org/TR/eventsource/#parsing-an-event-stream). The current tests force \r\n.

I cached this working on an implementation of SockJS for the Play Framework, which natively supports EventSource, but uses \n as the delimiter. I believe is a valid case for the tests to support either, as browsers should.
