### PR TITLE
Adding 'no-tranform' Cache-Control header to verify_not_cached.

### DIFF
--- a/sockjs-protocol.py
+++ b/sockjs-protocol.py
@@ -123,7 +123,7 @@ class Test(unittest.TestCase):
     # to disallow any caching.
     def verify_not_cached(self, r, origin=None):
         self.assertEqual(r['Cache-Control'],
-                         'no-store, no-cache, must-revalidate, max-age=0')
+                         'no-store, no-cache, no-transform, must-revalidate, max-age=0')
         self.assertFalse(r['Expires'])
         self.assertFalse(r['Last-Modified'])
 


### PR DESCRIPTION
Motivation:
When running the InfoTest.test_basic against the https://github.com/sockjs/sockjs-node
test_server I'm currently seeing the following failure:
```shell
$ ./venv/bin/python sockjs-protocol.py InfoTest.test_basic
F
======================================================================
FAIL: test_basic (__main__.InfoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "sockjs-protocol.py", line 269, in test_basic
    self.verify_not_cached(r)
  File "sockjs-protocol.py", line 126, in verify_not_cached
    'no-store, no-cache, must-revalidate, max-age=0')
AssertionError: 'no-store, no-cache, no-transform, must-revalidate,
max-age=0' != 'no-store, no-cache, must-revalidate, max-age=0'
- no-store, no-cache, no-transform, must-revalidate, max-age=0
?                    --------------
+ no-store, no-cache, must-revalidate, max-age=0

----------------------------------------------------------------------
Ran 1 test in 0.005s

FAILED (failures=1)
```
This headers was introduced in:
https://github.com/sockjs/sockjs-node/commit/7845866b0c1af24795f4a53cbf6a0e8f0468d7b5

Modifications:
Add the 'no-transform' Cache-Control header to verify_not_cheched.

Result:
The InfoTest.test_basic test passes successfully.