### PR TITLE
Slightly modernized

### DIFF
--- a/sockjs-protocol.py
+++ b/sockjs-protocol.py
@@ -164,11 +164,11 @@ class IframePage(Test):
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <script src="(?P<sockjs_url>[^"]*)"></script>
   <script>
     document.domain = document.domain;
-    SockJS.bootstrap_iframe\(\);
+    _sockjs_onload = function\(\){SockJS.bootstrap_iframe\(\);};
   </script>
+  <script src="(?P<sockjs_url>[^"]*)"></script>
 </head>
 <body>
   <h2>Don't panic!</h2>
@@ -492,6 +492,12 @@ class Protocol(Test):
 # WebSocket protocols: `/*/*/websocket`
 # -------------------------------------
 import websocket
+try:
+    from websocket import WebSocketConnectionClosedException
+except ImportError:
+    # Older version of websocket-client
+    from websocket import ConnectionClosedException \
+        as WebSocketConnectionClosedException
 
 # The most important feature of SockJS is to support native WebSocket
 # protocol. A decent SockJS server should support at least the
@@ -543,9 +549,9 @@ class WebsocketHixie76(Test):
         self.assertEqual(ws.recv(), u'c[3000,"Go away!"]')
 
         # The connection should be closed after the close frame.
-        with self.assertRaises(websocket.ConnectionClosedException):
+        with self.assertRaises(WebSocketConnectionClosedException):
             if ws.recv() is None:
-                raise websocket.ConnectionClosedException
+                raise WebSocketConnectionClosedException
         ws.close()
 
     # Empty frames must be ignored by the server side.
@@ -639,9 +645,9 @@ class WebsocketHixie76(Test):
         ws = websocket.create_connection(ws_url)
         self.assertEqual(ws.recv(), u'o')
         ws.send(u'["a')
-        with self.assertRaises(websocket.ConnectionClosedException):
+        with self.assertRaises(WebSocketConnectionClosedException):
             if ws.recv() is None:
-                raise websocket.ConnectionClosedException
+                raise WebSocketConnectionClosedException
         ws.close()
 
 
@@ -927,7 +933,7 @@ class EventSource(Test):
         url = base_url + '/000/' + str(uuid.uuid4())
         r = GET_async(url + '/eventsource')
         self.assertEqual(r.status, 200)
-        self.verify_content_type(r, 'text/event-stream')
+        self.verify_content_type(r, 'text/event-stream;charset=UTF-8')
         # As EventSource is requested using GET we must be very
         # careful not to allow it being cached.
         self.verify_not_cached(r)
@@ -1291,7 +1297,7 @@ class RawWebsocket(Test):
         ws = WebSocket8Client(close_base_url.replace('http', 'ws') + '/websocket')
         with self.assertRaises(ws.ConnectionClosedException) as ce:
             ws.recv()
-        self.assertEqual(ce.exception.reason, "Go away!")
+        self.assertIn(ce.exception.reason, ["Go away!", ''])
         ws.close()
 
 


### PR DESCRIPTION
Changes:

1. The websocket-client library no longer exports ``ConnectionClosedException``. It now exports ``WebSocketConnectionClosedException``. I updated the tests to match.

2. I updated the expected content of the hidden iframe. There is now a _sockjs_onload variable.

3. The raw websocket protocol is now allowed to close with an empty message.