### PR TITLE
Fix regex escape sequence

### DIFF
--- a/sockjs-protocol.py
+++ b/sockjs-protocol.py
@@ -167,7 +167,7 @@ class IframePage(Test):
   <script src="(?P<sockjs_url>[^"]*)"></script>
   <script>
     document.domain = document.domain;
-    SockJS.bootstrap_iframe\(\);
+    SockJS.bootstrap_iframe\\(\\);
   </script>
 </head>
 <body>


### PR DESCRIPTION
To resolve the error:

```
.../sockjs/sockjs-node/sockjs-protocol/sockjs-protocol.py:170: SyntaxWarning: "\(" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\("? A raw string is also an option.
  SockJS.bootstrap_iframe\(\);
  File "/home/jon/devel/sockjs/sockjs-node/sockjs-protocol/sockjs-protocol.py", line 592
    on_close = lambda(ws): self.assertFalse(True)
```